### PR TITLE
注記をメタ行の末尾に置き、長い注記で行が伸びるのを防ぐ

### DIFF
--- a/.claude/scripts/check-schedule-merge.sh
+++ b/.claude/scripts/check-schedule-merge.sh
@@ -126,7 +126,7 @@ check("line-through" in visible, "中止タイトルに取り消し線が無い"
 
 # ※ 行は廃止され、部屋変更は部屋の直後にインライン化されている
 check("※" not in text, "※ 行が残っている")
-check(re.search(r"760室\s*（[^）]+）", text) is not None, "部屋の補足が部屋の直後にインライン化されていない")
+check(re.search(r"760室.{0,40}（[^）]+）", text) is not None, "注記がメタ行にインライン化されていない")
 
 # 月見出しから uppercase が消えている
 check("uppercase" not in visible, "月見出しに uppercase が残っている")

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -67,10 +67,8 @@ const uniformTime = leadTimes.every((time) => time === leadTimes[0]);
 
       <p class="text-sm text-muted mt-2 flex flex-wrap items-center gap-x-4 gap-y-1">
         {uniformTime && <span>{leadTimes[0]}</span>}
-        <span>
-          {venueName[locale]} {formatRoomLabel(lead, locale)}
-          {leadNote && <span class="ml-1 text-xs">{wrapNote(leadNote, locale)}</span>}
-        </span>
+        <span>{venueName[locale]} {formatRoomLabel(lead, locale)}</span>
+        {leadNote && <span class="text-xs">{wrapNote(leadNote, locale)}</span>}
         {lead.chessResults && (
           <a
             href={lead.chessResults}

--- a/src/components/ScheduleEventBody.astro
+++ b/src/components/ScheduleEventBody.astro
@@ -69,11 +69,13 @@ const note = first.note?.[locale];
   {/* 中止した回の部屋と時刻は行き先の無い情報なので出さない */}
   {!cancelled && (
     <span class="inline-flex items-baseline gap-x-3">
-      <span class="text-ink">
-        {roomLabel}{note && <span class="ml-1 text-xs text-muted">{wrapNote(note, locale)}</span>}
-      </span>
+      <span class="text-ink">{roomLabel}</span>
       {uniformTime && <span class="text-muted">{times[0]}</span>}
     </span>
+  )}
+  {/* 注記は部屋・時刻どちらにも付くので、両方の後ろに置いて読み順を崩さない */}
+  {!cancelled && note && (
+    <span class="text-xs text-muted">{wrapNote(note, locale)}</span>
   )}
 </p>
 


### PR DESCRIPTION
#46 のフォローアップ。

`note` は部屋変更だけでなく**時刻変更にも使われる汎用フィールド**でした。#46 では部屋の直後に置いたため、時刻の注記が部屋と時刻の間に挟まって読み順が崩れ、文が長いと折り返して時刻が押し出されます。

実データ `2026-10-04`（`13時からです。9時からではありません`）で発生:

| 行 | #46 | 本PR |
|---|---|---|
| 10/04（時刻の注記） | 149px | **121px** |
| 09/06 など（部屋の注記） | 96px | 96px（変化なし） |

注記を部屋・時刻の**後ろ**に移動しました。日付 / 例会 / 部屋 / 時刻 という走査対象が先に揃い、補足が後ろに付きます。

検証: `pnpm check` エラー 0、`pnpm build` 89 ページ成功、check スクリプト全通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)