### PR TITLE
注意書きを中止理由と同じ形式に統一する

### DIFF
--- a/.claude/scripts/check-schedule-merge.sh
+++ b/.claude/scripts/check-schedule-merge.sh
@@ -126,7 +126,11 @@ check("line-through" in visible, "中止タイトルに取り消し線が無い"
 
 # ※ 行は廃止され、部屋変更は部屋の直後にインライン化されている
 check("※" not in text, "※ 行が残っている")
-check(re.search(r"760室.{0,40}（[^）]+）", text) is not None, "注記がメタ行にインライン化されていない")
+# 注意書きは中止理由も部屋・時刻の注記も同じ形式（左罫線つき独立行・括弧なし）
+notes = re.findall(r'<p class="([^"]*border-l-2[^"]*)"', visible)
+check(len(notes) >= 2, f"注記行が足りない ({len(notes)} 件)")
+check(len(set(notes)) == 1, f"注記行の形式が揃っていない: {set(notes)}")
+check("（" not in text, "注記に括弧が残っている")
 
 # 月見出しから uppercase が消えている
 check("uppercase" not in visible, "月見出しに uppercase が残っている")

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -3,7 +3,7 @@ import { getCollection } from "astro:content";
 import { t, getLocalePath, type Locale } from "@/i18n";
 import { formatMonthDay, getDayOfWeek } from "@/lib/date";
 import { getUpcomingScheduleDates } from "@/lib/schedule-data";
-import { groupScheduleDates, formatRoomLabel, wrapNote, getEventName } from "@/lib/schedule";
+import { groupScheduleDates, formatRoomLabel, getEventName } from "@/lib/schedule";
 import ScheduleEventBody from "@/components/ScheduleEventBody.astro";
 import SectionHeader from "@/components/SectionHeader.astro";
 import ExternalLinkIcon from "@/components/ExternalLinkIcon.astro";
@@ -68,7 +68,6 @@ const uniformTime = leadTimes.every((time) => time === leadTimes[0]);
       <p class="text-sm text-muted mt-2 flex flex-wrap items-center gap-x-4 gap-y-1">
         {uniformTime && <span>{leadTimes[0]}</span>}
         <span>{venueName[locale]} {formatRoomLabel(lead, locale)}</span>
-        {leadNote && <span class="text-xs">{wrapNote(leadNote, locale)}</span>}
         {lead.chessResults && (
           <a
             href={lead.chessResults}
@@ -82,6 +81,10 @@ const uniformTime = leadTimes.every((time) => time === leadTimes[0]);
           </a>
         )}
       </p>
+
+      {leadNote && (
+        <p class="text-xs text-sub mt-1.5 pl-3 border-l-2 border-edge">{leadNote}</p>
+      )}
 
       {!uniformTime && (
         <p class="text-xs text-muted mt-1 tabular-nums">

--- a/src/components/ScheduleEventBody.astro
+++ b/src/components/ScheduleEventBody.astro
@@ -1,6 +1,6 @@
 ---
 import { t, getLocalePath, type Locale } from "@/i18n";
-import { getEventName, formatRoomLabel, wrapNote, type ScheduleGroup } from "@/lib/schedule";
+import { getEventName, formatRoomLabel, type ScheduleGroup } from "@/lib/schedule";
 import { formatMonthDay, getDateParts, getDayOfWeek } from "@/lib/date";
 import ExternalLinkIcon from "@/components/ExternalLinkIcon.astro";
 
@@ -73,10 +73,6 @@ const note = first.note?.[locale];
       {uniformTime && <span class="text-muted">{times[0]}</span>}
     </span>
   )}
-  {/* 注記は部屋・時刻どちらにも付くので、両方の後ろに置いて読み順を崩さない */}
-  {!cancelled && note && (
-    <span class="text-xs text-muted">{wrapNote(note, locale)}</span>
-  )}
 </p>
 
 {!cancelled && !uniformTime && (
@@ -90,7 +86,8 @@ const note = first.note?.[locale];
   </p>
 )}
 
-{cancelled && note && (
+{/* 中止理由も部屋・時刻の注意も同じ「注意書き」なので同じ形式で出す */}
+{note && (
   <p class="text-xs text-sub mt-1.5 pl-3 border-l-2 border-edge">{note}</p>
 )}
 

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -87,11 +87,6 @@ export function formatRoomLabel(date: ScheduleDate, locale: Locale): string {
   return date.room ? `${date.room}${i.schedule.roomSuffix}` : i.schedule.roomTbd;
 }
 
-/** 部屋の補足などを括弧でくくる。日本語は全角、英語は半角。 */
-export function wrapNote(note: string, locale: Locale): string {
-  return locale === "ja" ? `（${note}）` : `(${note})`;
-}
-
 /**
  * Pages CMS reference の保存値 (例: "src/content/announcements/2026-06-29-75.md")
  * から announcements の slug ("2026-06-29-75") を取り出す。


### PR DESCRIPTION
#46 / #47 のフォローアップ。

## 直すこと

**1. トンマナが揃っていない** — 同じ「注意書き」なのに形式が2種類ありました。

| | 形式 |
|---|---|
| 大会の中止理由 | 左罫線つきの独立行・括弧なし |
| 例会の部屋・時刻の注記 | メタ行の中に括弧つき |

**2. 変な段落ち** — 注記をメタ行の flex item として置いていたため、長いと `flex-wrap` で2行目に落ちるだけで、罫線もインデントも無い状態でした（`2026-10-04` の `13時からです。9時からではありません`）。

## 直し方

中止理由と同じ `<p>` 形式に統一し、中止かどうかで出し分けていた2ブロックを1つに畳みました。括弧が不要になったので `wrapNote` を削除しています。

```
6 (日)
例会  740室  09:00–16:00
│ 通常は810A
```

## 結果（390px 実測）

| 行 | #47 | 本PR |
|---|---|---|
| メタ行の行数 | 10/04 のみ 2行 | **全行 1行**（段落ち解消） |
| 注記のクラス | 例会と大会で別 | **完全一致** |
| 注記ありの行 | 96 / 121px とばらつき | **122–123px で統一** |
| 注記なしの行 | 97px | 97px |
| 中止の行 | 143px | 143px |

注記のある行は 96 → 122px に戻りますが、形式の統一と段落ちの解消を優先しました。

検証: `pnpm check` エラー 0、`pnpm build` 89 ページ成功、check スクリプト全通過（`check-schedule-merge.sh` は「注記行の形式が全て一致し括弧が無いこと」を検証するよう更新）。ja/en 両方確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)