### PR TITLE
注記の英訳が空のとき英語版から消えるのを防ぐ

### DIFF
--- a/.claude/scripts/check-content-i18n.sh
+++ b/.claude/scripts/check-content-i18n.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# CMS コンテンツの ja/en 対応を検証する。
+#
+# Pages CMS は ja だけ埋めて en を空のまま保存できる。表示側は ja へ
+# フォールバックするので英語版から文言が消えることは無いが、日本語が
+# 出たままになるので気づけるようにする。
+#
+# 対象: schedule-meetings / schedule-tournaments の note・eventName
+
+set -e
+cd "$(dirname "$0")/../.."
+
+python3 - <<'PY'
+import pathlib, re, sys
+
+rc = 0
+for d in ["schedule-meetings", "schedule-tournaments"]:
+    for f in sorted(pathlib.Path(f"src/content/{d}").glob("*.md")):
+        text = f.read_text(encoding="utf-8")
+        for field in ["note", "eventName"]:
+            m = re.search(rf"^{field}:\s*\n((?:\s+\w+:.*\n?)+)", text, re.M)
+            if not m:
+                continue
+            blk = m.group(1)
+
+            def get(key):
+                mm = re.search(rf"^\s+{key}:\s*(.*)$", blk, re.M)
+                return mm.group(1).strip().strip('"').strip("'") if mm else ""
+
+            ja, en = get("ja"), get("en")
+            if ja and not en:
+                print(f"ERROR: {d}/{f.name} の {field}.en が空 (ja: {ja[:30]})")
+                rc = 1
+            if en and not ja:
+                print(f"ERROR: {d}/{f.name} の {field}.ja が空 (en: {en[:30]})")
+                rc = 1
+
+print("content: ja/en 揃い" if rc == 0 else "content: 英訳が欠けています")
+sys.exit(rc)
+PY

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -3,7 +3,7 @@ import { getCollection } from "astro:content";
 import { t, getLocalePath, type Locale } from "@/i18n";
 import { formatMonthDay, getDayOfWeek } from "@/lib/date";
 import { getUpcomingScheduleDates } from "@/lib/schedule-data";
-import { groupScheduleDates, formatRoomLabel, getEventName } from "@/lib/schedule";
+import { groupScheduleDates, formatRoomLabel, pickNote, getEventName } from "@/lib/schedule";
 import ScheduleEventBody from "@/components/ScheduleEventBody.astro";
 import SectionHeader from "@/components/SectionHeader.astro";
 import ExternalLinkIcon from "@/components/ExternalLinkIcon.astro";
@@ -27,7 +27,7 @@ const upcoming = rest.slice(0, 2);
 
 const lead = next?.[0];
 const isTournament = lead?.type === "tournament";
-const leadNote = lead?.note?.[locale];
+const leadNote = lead ? pickNote(lead, locale) : undefined;
 const leadTimes = next?.map((d) => `${d.startTime}–${d.endTime}`) ?? [];
 const uniformTime = leadTimes.every((time) => time === leadTimes[0]);
 ---

--- a/src/components/ScheduleEventBody.astro
+++ b/src/components/ScheduleEventBody.astro
@@ -1,6 +1,6 @@
 ---
 import { t, getLocalePath, type Locale } from "@/i18n";
-import { getEventName, formatRoomLabel, type ScheduleGroup } from "@/lib/schedule";
+import { getEventName, formatRoomLabel, pickNote, type ScheduleGroup } from "@/lib/schedule";
 import { formatMonthDay, getDateParts, getDayOfWeek } from "@/lib/date";
 import ExternalLinkIcon from "@/components/ExternalLinkIcon.astro";
 
@@ -33,7 +33,7 @@ const weekday = isRange
 const roomLabel = formatRoomLabel(first, locale);
 const times = group.map((d) => `${d.startTime}–${d.endTime}`);
 const uniformTime = times.every((time) => time === times[0]);
-const note = first.note?.[locale];
+const note = pickNote(first, locale);
 ---
 
 <p class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">

--- a/src/content/schedule-meetings/2026-08-23-2026-10-04.md
+++ b/src/content/schedule-meetings/2026-08-23-2026-10-04.md
@@ -5,6 +5,6 @@ endTime: 16:00
 room: "530"
 note:
   ja: 13時からです。9時からではありません
-  en: ""
+  en: "Starts at 13:00, not 9:00"
 cancelled: false
 ---

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -88,6 +88,17 @@ export function formatRoomLabel(date: ScheduleDate, locale: Locale): string {
 }
 
 /**
+ * 注記を取り出す。en が空なら ja にフォールバックする。
+ * CMS は en を空のまま保存できるため、フォールバックが無いと英語版から
+ * 注意書きが丸ごと消える。ja へ落とす方針はサイト共通 (pickTitle と同じ)。
+ */
+export function pickNote(date: ScheduleDate, locale: Locale): string | undefined {
+  const note = date.note;
+  if (!note) return undefined;
+  return (locale === "en" ? note.en || note.ja : note.ja) || undefined;
+}
+
+/**
  * Pages CMS reference の保存値 (例: "src/content/announcements/2026-06-29-75.md")
  * から announcements の slug ("2026-06-29-75") を取り出す。
  * slug 単体が渡された場合もそのまま返る。


### PR DESCRIPTION
## 症状

英語版スケジュールの 10/4 に注意書きが出ていませんでした。`2026-10-04` の `note.en` が空で、**「13時開始（9時ではない）」という時刻変更の警告が英語版から丸ごと消えていました**。

## 原因

サイト共通の方針は **en が無ければ ja へフォールバック**（`pickTitle` / `pickDescription`）ですが、スケジュールの注記だけ `note?.[locale]` の直接参照でフォールバックがありませんでした。`optionalI18n` は `en: ""` を許すため、静かに空文字が返っていました。

## 直し方

1. `pickNote` を追加し、`ScheduleEventBody` / `Schedule` から使う（en が空なら ja へ）
2. 欠けていた英訳を補う（`Starts at 13:00, not 9:00`）
3. `check-content-i18n.sh` を追加。CMS が片方の言語だけで保存されたケースを CI で検知する

## 他に同じ穴が無いかの確認

`[locale]` の直接参照を全て洗いました。

| 参照 | 判定 |
|---|---|
| `site.venue.name/address/access` | スキーマで ja・en とも必須 — 安全 |
| `link.title` | 同上 — 安全 |
| `lesson.title/description` | 同上 — 安全 |
| `eventName` | `getEventName` が ja へフォールバック済み — 安全 |
| **`note`** | **フォールバック無し — 本PRで修正** |

コンテンツ側も全件走査し、ja/en の欠落は `2026-10-04` の 1 件のみでした。

## 検証

`pnpm check` エラー 0、`pnpm build` 89 ページ成功、check スクリプト 5 本すべて PASS。新しい guard はわざと `en: ""` に戻して exit 1 になることを確認済み。ja/en 両方で注意書きの表示を確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)