### PR TITLE
会場の部屋案内を文中リンクにする

### DIFF
--- a/src/components/ClubInfo.astro
+++ b/src/components/ClubInfo.astro
@@ -17,6 +17,9 @@ const site = siteData[0].data;
 // 部屋は開催日ごとに異なる (810A / 740 / 760 / 1010 …) ため会場欄には固定記載せず、
 // 各回の部屋番号を持つスケジュールへ誘導する。
 const scheduleHref = getLocalePath(locale, "/schedule/");
+
+// 文中の {link} をリンクに置き換える。ja/en で語順が違うので前後に分割する。
+const [roomNoticeBefore, roomNoticeAfter] = i.clubInfo.roomNotice.split("{link}");
 ---
 
 <section id="info" class="px-5 py-10">
@@ -43,13 +46,10 @@ const scheduleHref = getLocalePath(locale, "/schedule/");
       <div class="flex flex-col gap-1 text-sm text-sub">
         <p class="text-ink font-medium">{site.venue.name[locale]}</p>
         <p>
-          {i.clubInfo.roomNotice}
-          <a
+          {roomNoticeBefore}<a
             href={scheduleHref}
             class="text-primary [@media(hover:hover)]:hover:underline underline-offset-2"
-          >
-            {i.clubInfo.checkSchedule}
-          </a>
+          >{i.clubInfo.checkSchedule}</a>{roomNoticeAfter}
         </p>
         <p>{site.venue.address[locale]}</p>
         <p class="text-muted text-xs mt-1">{site.venue.access[locale]}</p>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -103,8 +103,9 @@ export default {
     observation: "Observation & First Visit",
     free: "Free",
     viewOnMap: "View on Google Maps",
-    roomNotice: "The room varies by date.",
-    checkSchedule: "Check the schedule",
+    // {link} は checkSchedule のリンクに置換される
+    roomNotice: "The room varies by {link}.",
+    checkSchedule: "schedule",
   },
   lessons: {
     label: "Chess Lessons",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -89,8 +89,9 @@ export default {
     observation: "見学・初回参加",
     free: "無料",
     viewOnMap: "Google マップで見る",
-    roomNotice: "部屋は開催日により異なります。",
-    checkSchedule: "スケジュールで確認",
+    // {link} は checkSchedule のリンクに置換される
+    roomNotice: "部屋は{link}により異なります。",
+    checkSchedule: "スケジュール",
   },
   lessons: {
     label: "チェス講座",


### PR DESCRIPTION
## 変更

| | 変更前 | 変更後 |
|---|---|---|
| ja | 部屋は開催日により異なります。**スケジュールで確認** | 部屋は**スケジュール**により異なります。 |
| en | The room varies by date. **Check the schedule** | The room varies by **schedule**. |

文＋独立リンクの形をやめ、文中の「スケジュール」だけをリンクにしました。

## 実装

`ja`/`en` で語順が違うため、`roomNotice` に `{link}` プレースホルダを置いて表示側で前後に分割しています（`tournament.filterAnnounce` と同じプレースホルダ方式）。

```
ja: 部屋は{link}により異なります。   + checkSchedule: スケジュール
en: The room varies by {link}.     + checkSchedule: schedule
```

リンク規約は維持: `text-primary` ＋ `[@media(hover:hover)]:hover:underline underline-offset-2`（青リンクは hover 下線のみ・色静止）。アンカーテキストが行き先名そのものになるので「無情報アンカー禁止」の規約にも沿います。

## 検証

`pnpm check` エラー 0、`pnpm build` 89 ページ成功、check スクリプト 5 本すべて PASS。ja/en 両方でレンダリング確認済み（1 行に収まる）。

## 補足

原文は「部屋は**開催日**により異なります」で、部屋を左右するのは日付でした。新しい文は「スケジュールにより異なります」でやや循環気味（スケジュールは日付の一覧）ですが、読み手にとっては「スケジュールを見れば部屋が分かる」と直接読めるので実用上は問題ないと判断しています。日付の情報を残したい場合は `部屋は開催日により異なります。{link}をご確認ください。` の形にもできます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)