### PR TITLE
活動内容を地色の面にする

### DIFF
--- a/src/components/Activities.astro
+++ b/src/components/Activities.astro
@@ -18,9 +18,9 @@ const cards = [
 
 <section id="activities" class="px-5 py-10">
   <SectionHeader label={i.activities.label} />
-  <div class="grid grid-cols-1 sm:grid-cols-3 gap-x-8 gap-y-5">
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
     {cards.map((card) => (
-      <div>
+      <div class="bg-surface px-6 py-7">
         <p class="text-base font-semibold">{card.title}</p>
         <p class="text-xs text-muted mt-1">{card.desc}</p>
       </div>


### PR DESCRIPTION
## 経緯

#46 で箱（`bg-surface rounded-md p-4 min-h-[90px]`）を外しましたが、**箱がやっていたグルーピングを何にも引き継がせていませんでした**。

- モバイル: 項目内 4px に対し項目間 20px（5:1）しかなく、6 行が平坦に並ぶ
- デスクトップ: 896px の幅に短いテキストが 3 つ載っているだけ

余白・罫線・overline の案も作りましたが、方向として色面が選ばれました。

## 変更

各列を `bg-surface` の面にします。#46 以前の箱とは違い、**角丸も影も `min-height` も持ちません**。パディングを広げて（`px-6 py-7`）面として見せます。

```
grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4
  └ div.bg-surface.px-6.py-7
```

## 実測

| | デスクトップ (1280px) | モバイル (390px) |
|---|---|---|
| レイアウト | 3列 | 縦積み |
| 地色 | `#fafafa` | 同左 |
| 角丸 / 影 | `0px` / `none` | 同左 |
| パディング | 28px / 24px | 同左 |
| 列の高さ | 108px × 3（grid stretch で揃う） | 同左 |
| 間隔 | 16px | 12px |

生 hex は使わず、既存トークン `bg-surface` のみです。

## 検証

`pnpm check` エラー 0、`pnpm build` 89 ページ成功、check スクリプト 5 本すべて PASS。ja/en・デスクトップ/モバイルで確認済み、横スクロールなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)