### PR TITLE
大会の説明を「北海道選手権など年3回」にする

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -74,7 +74,7 @@ export default {
     meetup: "Meetups",
     meetupDesc: "Twice a month",
     tournament: "Tournaments",
-    tournamentDesc: "3 per year",
+    tournamentDesc: "Hokkaido Championship, 3 per year",
     lesson: "Lessons",
     lessonDesc: "By a member, off-site",
   },

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -60,7 +60,7 @@ export default {
     meetup: "例会",
     meetupDesc: "月2回の定期開催",
     tournament: "大会",
-    tournamentDesc: "年3回の公式戦",
+    tournamentDesc: "北海道選手権など年3回",
     lesson: "講座",
     lessonDesc: "メンバーが別会場で開講",
   },


### PR DESCRIPTION
## 問題

| | 変更前 |
|---|---|
| 例会 | 月2回の定期開催 |
| 大会 | **年3回の公式戦** |
| 講座 | メンバーが別会場で開講 |

「公式戦」は誤りではありませんが、**例会との区別になっていません**。例会も日本チェス連盟公式レートのかかった対局が中心で、大会側の告知にも「札幌サマーチェス大会は日本チェス連盟公式戦のため、会員登録が必要です」とあり、公式であることは両者に共通します。

## 変更

| | 変更後 |
|---|---|
| ja | 大会 / **北海道選手権など年3回** |
| en | Tournaments / **Hokkaido Championship, 3 per year** |

看板大会の名前を出して具体的にしました。レート・棋力には触れていません（初心者が身構える表現を避ける方針のため）。

英語は `3 per year` のみで日本語と情報量が揃っていなかったので合わせています。

## 検討した他の案

- `年3回の公式大会` — 「公式戦」より自然だが、区別にならない問題は残る。見出し「大会」とも重なる
- `年3回・2日間開催` — 事実のみだが、ラウンド制・表彰といった大会の性格が伝わらない
- `年3回開催` — 誤りは消えるが情報量が最少

## 検証

`pnpm check` エラー 0、`pnpm build` 89 ページ成功、check スクリプト 5 本すべて PASS。

ja/en とも説明は **1 行に収まり**、面の高さは 108px のまま 3 列揃っています（1280px で実測）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)